### PR TITLE
Use cwd in exec instead of passing it as an argument

### DIFF
--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -69,12 +69,12 @@ class Linter
     self = this
     if @config.type is 'local'
       dir = path.dirname(localPath).replace(' ', '\\ ') #escaping spaces
-      exec "hh_client --json --from atom #{localPath}",(_,__,stderr)->
+      exec "hh_client --json --from atom", {"cwd": dir}, (_,__,stderr)->
         self.setErrors(stderr)
         self.redraw()
     else if @config.type is 'remote'
       dir = path.dirname(localPath).replace(@config.localDir,@config.remoteDir).split('\\').join(path.sep).replace(' ','\\ ')
-      @ssh.exec("hh_client --json --from atom #{dir}").then (result)->
+      @ssh.exec("hh_client --json --from atom", {"cwd": dir}).then (result)->
         self.setErrors(result.stderr)
         self.redraw()
   setErrors:(output)->


### PR DESCRIPTION
hh_client is unable to properly find the .hhconfig file when passing the directory as an argument

See https://github.com/facebook/hhvm/issues/3643
(The commit is not in a stable release yet)
