### PR TITLE
Vagant `hh_client` Errors

### DIFF
--- a/lib/h.coffee
+++ b/lib/h.coffee
@@ -38,6 +38,7 @@ module.exports = (Main)->
         else
           LePromise = Promise.resolve()
         LePromise.then =>
+          @SSH.exec('touch ' + RemotePath)
           @SSH.exec(command+' '+args.join(' '),{cwd:RemotePath.split('/').slice(0,-1).join('/')}).then (result)->
             resolve(result)
     @execLocal:(args,input,path)->


### PR DESCRIPTION
When using hhvm on a vagrant box and developing against local files the files on the vagant machine, while updated, are not triggering hh_client to check for errors. Using `touch` before checking hh_client enables the error check to successfully update the log and return valid error messages.