### PR TITLE
Correct vagrant hh_client not auto updating on Mac

### DIFF
--- a/lib/atom-hack.coffee
+++ b/lib/atom-hack.coffee
@@ -47,6 +47,8 @@ module.exports = AtomHack =
           FilePath = ActiveEditor.getPath()
           return Resolve([]) unless FilePath or AtomHack.Hack.config.status # Files that have not be saved
           if AtomHack.Hack.config.type is 'local' or not AtomHack.Hack.config.autoPush
+            FileName = FilePath.split('/').pop();
+            AtomHack.Hack.exec('touch ' + FileName, Path.dirname(FilePath));
             LePromise = AtomHack.Hack.exec('hh_client --json', Path.dirname(FilePath))
           else
             LePromise = AtomHack.Hack.transfer(FilePath).then ->

--- a/lib/atom-hack.coffee
+++ b/lib/atom-hack.coffee
@@ -48,8 +48,8 @@ module.exports = AtomHack =
           return Resolve([]) unless FilePath or AtomHack.Hack.config.status # Files that have not be saved
           if AtomHack.Hack.config.type is 'local' or not AtomHack.Hack.config.autoPush
             FileName = FilePath.split('/').pop();
-            AtomHack.Hack.exec('touch ' + FileName, Path.dirname(FilePath));
-            LePromise = AtomHack.Hack.exec('hh_client --json', Path.dirname(FilePath))
+            LePromise = AtomHack.Hack.exec('touch ' + FileName, Path.dirname(FilePath)).then ->
+                AtomHack.Hack.exec('hh_client --json', Path.dirname(FilePath))
           else
             LePromise = AtomHack.Hack.transfer(FilePath).then ->
               AtomHack.Hack.exec('hh_client --json', Path.dirname(FilePath))


### PR DESCRIPTION
When using hhvm on a vagrant box and developing against local files the files on the vagant machine, while updated, are not triggering hh_client to check for errors. Using touch before checking hh_client enables the error check to successfully update the log and return valid error messages.

This is the same problem from before the rewrite was complete. After using the new version, I found this to be the best way to fix hh_clinet not updating.