### PR TITLE
'touch' files in 'Bash on Windows' mode

### DIFF
--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -52,6 +52,11 @@ export default class Delegate {
   }
   async uploadFile(localFile: string) {
     if (this.config.type === 'local' || !this.config.uploadFiles) {
+      if (process.platform === 'win32' && this.supportBashOnWindows) {
+        const chunks = localFile.split(':')
+        const newPath = `/mnt/${chunks.shift().toLowerCase()}/${chunks.join(':').split('\\').join('/')}`
+        await exec(getCmdPath(), ['/c', `bash -c 'touch -am ${newPath}'`], { ignoreExitCode: true, stream: 'both' })
+      }
       return
     }
     invariant(this.ssh)


### PR DESCRIPTION
The current implementation of WSL does does support propagation of NTFS file events in WSL. So, we `touch` modified files as a workaround.